### PR TITLE
add nested expression testcase

### DIFF
--- a/nested_condition
+++ b/nested_condition
@@ -1,0 +1,4 @@
+let x=2 in
+if (x=1) then x 
+else if (x=2) then x+1
+else x+10


### PR DESCRIPTION
input program 
`let x=2 in
if (x=1) then x 
else if (x=2) then x+1
else x+10` produces 

Fatal error: exception Parser.MenhirBasics.Error

However,
`let x=2 in
if (x=1) then x 
else (if (x=2) then x+1
else x+10)`

works well

this may be a precedence error too.
